### PR TITLE
FR#224 Copy Search results

### DIFF
--- a/src/NotepadNext/docks/SearchResultsDock.cpp
+++ b/src/NotepadNext/docks/SearchResultsDock.cpp
@@ -25,6 +25,7 @@
 #include <QPointer>
 #include <QMenu>
 #include <QShortcut>
+#include <QClipboard>
 
 enum SearchResultData
 {
@@ -210,3 +211,18 @@ void SearchResultsDock::updateSearchStatus()
     if (currentFile)
         currentFile->setText(0, QStringLiteral("%1 (%L2 hits)").arg(currentFilePath).arg(totalFileHitCount));
 }
+
+void SearchResultsDock::on_pb_copyResults_released()
+{
+    QClipboard *clipboard = QGuiApplication::clipboard();
+    QString string;
+
+    QTreeWidgetItemIterator it(ui->treeWidget);
+    while (*it) {
+        string.append((*it)->text(0) + ' ' + (*it)->text(1) + '\n');
+        ++it;
+    }
+
+    clipboard->setText(string) ;
+}
+

--- a/src/NotepadNext/docks/SearchResultsDock.h
+++ b/src/NotepadNext/docks/SearchResultsDock.h
@@ -54,6 +54,8 @@ private slots:
     void itemActivated(QTreeWidgetItem *item, int column);
     void itemExpanded(QTreeWidgetItem *item);
 
+    void on_pb_copyResults_released();
+
 signals:
     void searchResultActivated(ScintillaNext *editor, int lineNumber, int startPositionFromBeginning, int endPositionFromBeginning);
 

--- a/src/NotepadNext/docks/SearchResultsDock.ui
+++ b/src/NotepadNext/docks/SearchResultsDock.ui
@@ -31,6 +31,13 @@
      <number>0</number>
     </property>
     <item>
+     <widget class="QPushButton" name="pb_copyResults">
+      <property name="text">
+       <string>Copy Results to Clipboard</string>
+      </property>
+     </widget>
+    </item>
+    <item>
      <widget class="QTreeWidget" name="treeWidget">
       <property name="font">
        <font>


### PR DESCRIPTION
Adds a button to the search results panel that causes the contents of the search window to be copied to the clipboard
